### PR TITLE
Tracing

### DIFF
--- a/gologger/gologger.go
+++ b/gologger/gologger.go
@@ -14,6 +14,15 @@ type ctxKey string
 
 const ReqIDKey ctxKey = "reqID"
 
+type (
+	Action struct {
+		DurationNS int64
+		Statement  string `json:",omitempty"`
+		Exec       bool   `json:",omitempty"`
+		NumRows    *int   `json:",omitempty"`
+	}
+)
+
 func init() {
 	l := NewLogger()
 	zerolog.DefaultContextLogger = &l

--- a/gologger/gologger.go
+++ b/gologger/gologger.go
@@ -18,6 +18,7 @@ type (
 	Action struct {
 		DurationNS int64
 		Statement  string `json:",omitempty"`
+		Error      string `json:",omitempty"`
 		Exec       bool   `json:",omitempty"`
 		NumRows    *int   `json:",omitempty"`
 	}

--- a/http_server/query.go
+++ b/http_server/query.go
@@ -45,7 +45,7 @@ func (s *HTTPServer) PostQuery(c *CustomContext) error {
 }
 
 func (s *HTTPServer) PostBegin(c *CustomContext) error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, cancel := context.WithTimeout(c.Request().Context(), time.Second*10)
 	defer cancel()
 
 	txID, err := pg.Manager.NewTx(ctx)
@@ -68,7 +68,7 @@ func (s *HTTPServer) PostCommit(c *CustomContext) error {
 	}
 	defer c.Request().Body.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, cancel := context.WithTimeout(c.Request().Context(), time.Second*10)
 	defer cancel()
 
 	err := pg.Manager.CommitTx(ctx, body.TxID)
@@ -100,7 +100,7 @@ func (s *HTTPServer) PostRollback(c *CustomContext) error {
 	}
 	defer c.Request().Body.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, cancel := context.WithTimeout(c.Request().Context(), time.Second*10)
 	defer cancel()
 
 	err := pg.Manager.RollbackTx(ctx, body.TxID)

--- a/utils/env.go
+++ b/utils/env.go
@@ -24,4 +24,7 @@ var (
 
 	// Whether to use https for inter-pod communication, defaults to false
 	POD_HTTPS = os.Getenv("POD_HTTPS") == "1"
+
+	// Whether to emit traces in the HTTP logs
+	TRACES = os.Getenv("TRACES") == "1"
 )


### PR DESCRIPTION
Moves tracing to join the logging context, giving the final HTTP log lots of info.

Prevents additional logging needed so everything can be done with a single log line in terms of performance tracing