### PR TITLE
Optionally specify timeout for transaction (default 30s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,14 @@ Any query errors that occur will be included in the response body, rather than f
 
 Starts a new transaction.
 
+Request Body:
+
+```
+{
+    TxTimeoutSec: *int64 // sets the garbage collection timeout, default `30`
+}
+```
+
 Returns the transaction ID that must be carried through subsequent requests.
 
 Response Body:

--- a/pg/pool.go
+++ b/pg/pool.go
@@ -59,6 +59,10 @@ type (
 		TxID string
 	}
 
+	BeginRequest struct {
+		TxTimeoutSec *int64
+	}
+
 	DistributedError struct {
 		Err        error
 		Remote     bool

--- a/pg/tx_manager.go
+++ b/pg/tx_manager.go
@@ -56,10 +56,10 @@ func NewTxManager() *TxManager {
 }
 
 // NewTx starts a new transaction, returning the ID
-func (manager *TxManager) NewTx(ctx context.Context) (string, error) {
+func (manager *TxManager) NewTx(ctx context.Context, timeoutSec *int64) (string, error) {
 	txID := utils.GenRandomID("tx")
 
-	expireTime := time.Now().Add(time.Second * 30)
+	expireTime := time.Now().Add(time.Second * time.Duration(utils.Deref(timeoutSec, 30)))
 	poolConn, err := PGPool.Acquire(ctx)
 	if err != nil {
 		return "", fmt.Errorf("error in PGPool.Acquire: %w", err)


### PR DESCRIPTION
Closes #15 

Adds the capability to specify a timeout for transactions